### PR TITLE
corrected syntax highlighting error

### DIFF
--- a/Arduino.sublime-syntax
+++ b/Arduino.sublime-syntax
@@ -10,6 +10,7 @@ contexts:
     - match: ''
       push: Packages/C++/C++.sublime-syntax
       with_prototype:
+        - include: comments
         - match: \b(HIGH|LOW|INPUT|OUTPUT|INPUT_PULLUP|LED_BUILTIN)\b
           scope: constant.language.arduino
         - match: \b(boolean|word|String|string|array)\b
@@ -20,3 +21,30 @@ contexts:
           scope: entity.name.class.arduino
         - match: \b(pinMode|digitalWrite|digitalRead|analogReference|analogRead|analogWrite|analogReadResolution|analogWriteResolution|tone|noTone|shiftOut|shiftIn|pulseIn|millis|micros|delay|delayMicroseconds|min|max|constrain|map|pow|sqrt|sin|cos|tan|isAlphaNumeric|isAlpha|isAscii|isWhitespace|isControl|isDigit|isGraph|isLowerCase|isPrintable|isPunct|isSpace|isUpperCase|isHexadecimalDigit|randomSeed|random|lowByte|highByte|bitRead|bitWrite|bitSet|bitClear|bit|attachInterrupt|detachInterrupt|interrupts|noInterrupts)\b
           scope: entity.name.function.arduino
+  comments:
+    - match: ^/\* =(\s*.*?)\s*= \*/$\n?
+      scope: comment.block.c
+      captures:
+        1: meta.toc-list.banner.block.c
+    - match: /\*
+      scope: punctuation.definition.comment.c
+      push:
+        - meta_scope: comment.block.c
+        - match: \*/
+          scope: punctuation.definition.comment.c
+          pop: true
+    - match: \*/(?!\*)
+      scope: invalid.illegal.stray-comment-end.c
+    - match: ^// =(\s*.*?)\s*=\s*$\n?
+      scope: comment.line.banner.c
+      captures:
+        1: meta.toc-list.banner.line.c
+    - match: //
+      scope: punctuation.definition.comment.c
+      push:
+        - meta_scope: comment.line.double-slash.c
+        - match: '(\\)$\n'
+          captures:
+            1: punctuation.separator.continuation.c
+        - match: \n
+          pop: true


### PR DESCRIPTION
syntax from this file stay highlighted even commented due to use of with_prototype:
corrected this by adding a complete comment context from C.sublime-syntax file. to Arduino.sublime-syntax file
[Corrected_Arduino.sublime-syntax.zip](https://github.com/nuwantha2020/Stino/files/1167384/Corrected_Arduino.sublime-syntax.zip)
